### PR TITLE
Allied magic resist for global spells fix

### DIFF
--- a/assembly/patches/MMH55 production patches/for stripped exe/magic_resistance_mod_v2.yml
+++ b/assembly/patches/MMH55 production patches/for stripped exe/magic_resistance_mod_v2.yml
@@ -2,20 +2,24 @@
 # ----------------- Magic resistance mod --------------
 # ----------------------------------------------------
 #
-# Alters existing spell resistance function. Creates and binds more to game artifacts, abilities, perks.
+# Alters existing spell resistance function.
+# Creates and binds more game artifacts, abilities, perks with resistance.
 # - Plate of Forgotten Hero magic resist can be changed by modifying FORGOTTEN_HERO_PLATE_MR
 # - Boots of Interference magic resist can be changed by modifying INTERFERENCE_BOOTS_MR
 # - Added new artifact with ID 173 that provides ARTIFACT01_MR% resistance
 # - Added new artifact with ID 174 that provides ARTIFACT02_MR% resistance
+# 
+# Fixes:
+# - Fixed Magic resistance not triggering for caster hero troops for Armageddon, Curse of the Netherworld and Word of Light spells
 #
 #----------------- VALUES TO MODIFY ---------------------
 definitions: 
- - &FORGOTTEN_HERO_PLATE_MR  30
- - &INTERFERENCE_BOOTS_MR    20
+ - &FORGOTTEN_HERO_PLATE_MR  10
+ - &INTERFERENCE_BOOTS_MR    15
  - &ARTIFACT01_ID           173
- - &ARTIFACT01_MR            51
+ - &ARTIFACT01_MR             5
  - &ARTIFACT02_ID           174
- - &ARTIFACT02_MR            50
+ - &ARTIFACT02_MR            10
 #----------------- DO NOT MODIFY ---------------------
  - &TOE_FORGOTTEN_HERO_PLATE_MR 20
  - &TOE_INTERFERENCE_BOOTS_MR 10
@@ -114,6 +118,16 @@ group: Original
 patchAddress:   00BD9D7C  ## 01136D7C                           ##     
 originalBytes:  00*
 patchBytes:     89 6C 24 10 8B 16 89 F1 FF 52 74 E9 78 62 84 FF
+---
+group: Original
+patchAddress:   0057C310  ## 0097CF10                           ## Fork Magic resist to new "Skip logic code"
+originalBytes:  8B CB E8 09 76 0B 00 84 C0 74 1F 85 FF 74 0F
+patchBytes:     E9 7B 9E 7B 00 90 90 90 90 90 90 90 90 90 90
+---
+group: Original                                                 ## MAGIC RESIST skip logic changed   
+patchAddress:   00BD9D90  ## 01136D90                           ## from ALLIED(Hero,Combat) == TRUE AND CAN_SPELL_TARGET_ALLY == TRUE                      
+originalBytes:  00*                                             ## to   ALLIED(Hero,Combat) == TRUE ANDD IS_SPELL_DEALING_DAMAGE == FALSE 
+patchBytes:     8B 54 24 30 89 D9 E8 15 EF 3A FF 84 C0 0F 85 97 61 84 FF E9 77 61 84 FF
 --- # --------------- QUANTOMAS 3.1j PATCH DATA ---------------
 group: Quantomas3.1j
 checkAddress:   00000400
@@ -209,3 +223,13 @@ group: Quantomas3.1j
 patchAddress:   00BD9D7C  ## 01146D7C                           ##     
 originalBytes:  00*
 patchBytes:     89 6C 24 10 8B 16 89 F1 FF 52 74 E9 15 23 77 FF
+---
+group: Quantomas3.1j
+patchAddress:   004B83B1  ## 008B8FB1                           ## Fork Magic resist to new "Skip logic code"
+originalBytes:  8B CB E8 38 CD 01 00 84 C0 74 1B
+patchBytes:     E9 DA DD 88 00 90 90 90 90 90 90
+---
+group: Quantomas3.1j                                            ## MAGIC RESIST skip logic changed   
+patchAddress:   00BD9D90  ## 01146D90                           ## from ALLIED(Hero,Combat) == TRUE AND CAN_SPELL_TARGET_ALLY == TRUE                      
+originalBytes:  00*                                             ## to   ALLIED(Hero,Combat) == TRUE ANDD IS_SPELL_DEALING_DAMAGE == FALSE 
+patchBytes:     8B 54 24 30 89 D9 E8 C5 07 84 FF 84 C0 0F 85 34 22 77 FF E9 14 22 77 FF


### PR DESCRIPTION
Fixed Magic resistance not triggering for caster hero troops for Armageddon, Curse of the Netherworld and Word of Light spells

Closes #105 