### PR TITLE
disable magic resist notification from enemy specialization or artifacts 

### DIFF
--- a/assembly/patches/MMH55 production patches/for stripped exe/disable_magic_resist_for_non_damaging_spells.yml
+++ b/assembly/patches/MMH55 production patches/for stripped exe/disable_magic_resist_for_non_damaging_spells.yml
@@ -1,0 +1,55 @@
+# ----------------------------------------------------
+# ----------------- Magic Resist disabled for non damagig spells --------------
+# ----------------------------------------------------
+#
+# Spells that do not do direct damage:
+# - will not trigger magic resist
+# - will have any magic resist notification from enemy specialization or artifacts removed as they do cause it to be resisted
+# 
+# However immunities for non damaging spells will still work.
+# 
+# ----------------------------------------------------
+--- # ----------- ORIGINAL EXE 3.1 PATCH DATA ------------
+group: Original
+checkAddress:   00000400
+checkBytes:     8D 41 34 C3 CC CC CC CC
+patchAddress:   004B87B6           ## 0097D316 - jump to new code
+originalBytes:  85 C0 0F 8E D9 00 00 00
+patchBytes:     E9 85 BB 7B 00 90 90 90
+---
+group: Original                    ## new code - if spell does not deal damage skip magic resist rolls
+patchAddress:   00BDBEA0           ## 01138EA0
+originalBytes:  00*
+patchBytes:     85 C0 0F 8E 4F 45 84 FF 89 FA 89 E9 E8 FF CD 3A FF 84 C0 0F 84 3E 45 84 FF E9 60 44 84 FF
+---
+group: Original                    ## fork from magic resist specializations and artifacts calculation and notification system
+patchAddress:   0057C3CB           ## 0097CFCB
+originalBytes:  8B 16 6A 0F 8B CE
+patchBytes:     E9 F2 BE 7B 00 90
+---
+group: Original                    ## skip the system of spell is not dealing damage
+patchAddress:   00BDBEC2           ## 01138EC2
+originalBytes:  00*
+patchBytes:     8B 54 24 30 8B 4C 24 2C E8 E1 CD 3A FF 84 C0 0F 84 7A 41 84 FF 8B 16 6A 0F 89 F1 E9 EF 40 84 FF
+--- # --------------- QUANTOMAS 3.1j PATCH DATA ---------------
+group: Quantomas3.1j
+checkAddress:   00000400
+checkBytes:     56 57 8B 7C 24 0C 57 8B F1 E8 D2 B7 00 00 83 C4
+patchAddress:   004B87B6           ## 008B93B6 - jump to new code
+originalBytes:  85 C0 0F 8E D9 00 00 00
+patchBytes:     E9 E5 FA 88 00 90 90 90
+---
+group: Quantomas3.1j               ## new code - if spell does not deal damage skip magic resist rolls
+patchAddress:   00BDBEA0           ## 01148EA0
+originalBytes:  00*
+patchBytes:     85 C0 0F 8E EF 05 77 FF 89 FA 89 E9 E8 AF E6 83 FF 84 C0 0F 84 DE 05 77 FF E9 00 05 77 FF
+---
+group: Quantomas3.1j               ## fork from magic resist specializations and artifacts calculation and notification system
+patchAddress:   004B8468           ## 008B9068
+originalBytes:  8B 16 6A 0F 8B CE
+patchBytes:     E9 55 FE 88 00 90
+---
+group: Quantomas3.1j               ## skip the system of spell is not dealing damage
+patchAddress:   00BDBEC2           ## 01148EC2
+originalBytes:  00*
+patchBytes:     8B 54 24 30 8B 4C 24 2C E8 91 E6 83 FF 84 C0 0F 84 17 02 77 FF 8B 16 6A 0F 89 F1 E9 8C 01 77 FF


### PR DESCRIPTION
magic resist notification from enemy specialization or artifacts removed as they do cause it to be resisted # However immunities for non damaging spells will still work.

Closes #109 